### PR TITLE
Render progress tracking and cancel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "built"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +223,12 @@ name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -362,6 +377,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +415,18 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+dependencies = [
+ "bitflags 2.9.3",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -790,9 +828,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -936,6 +974,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225e7cfe711e0ba79a68baeddb2982723e4235247aefce1482f2f16c27865b66"
+dependencies = [
+ "bitflags 2.9.3",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1022,6 +1072,21 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "objc2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
@@ -1302,6 +1367,7 @@ name = "rusty-rays-cli"
 version = "0.2.0"
 dependencies = [
  "clap",
+ "ctrlc",
  "rusty-rays-core",
  "signal-hook",
 ]
@@ -1882,6 +1948,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,6 +448,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "exr"
 version = "1.73.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1293,6 +1303,7 @@ version = "0.2.0"
 dependencies = [
  "clap",
  "rusty-rays-core",
+ "signal-hook",
 ]
 
 [[package]]
@@ -1391,6 +1402,26 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b57709da74f9ff9f4a27dce9526eec25ca8407c45a7887243b031a58935fb8e"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "simd-adler32"

--- a/rusty-rays-cli/Cargo.toml
+++ b/rusty-rays-cli/Cargo.toml
@@ -14,4 +14,5 @@ path = "src/main.rs"
 [dependencies]
 rusty-rays-core = { path = "../rusty-rays-core" }
 clap = { version = "4.5.14", features = ["derive"] }
-signal-hook = "0.4.3"
+signal-hook = { version = "0.4.3",features = ["iterator"] }
+ctrlc = "3.5.2"

--- a/rusty-rays-cli/Cargo.toml
+++ b/rusty-rays-cli/Cargo.toml
@@ -14,3 +14,4 @@ path = "src/main.rs"
 [dependencies]
 rusty-rays-core = { path = "../rusty-rays-core" }
 clap = { version = "4.5.14", features = ["derive"] }
+signal-hook = "0.4.3"

--- a/rusty-rays-cli/src/main.rs
+++ b/rusty-rays-cli/src/main.rs
@@ -3,10 +3,11 @@ use std::path::PathBuf;
 use std::thread;
 
 use rusty_rays_core::logger::{error, info, shutdown_logger, LOG};
-use rusty_rays_core::{write_render_to_file, CancellationToken, Model, Tracer};
+use rusty_rays_core::{write_render_to_file, Model, Tracer};
 
 // Add this dependency in Cargo.toml:
 // signal-hook = "0.3"
+use rusty_rays_core::CancellationToken;
 use signal_hook::consts::signal::{SIGINT, SIGTERM, SIGTSTP};
 use signal_hook::iterator::Signals;
 

--- a/rusty-rays-cli/src/main.rs
+++ b/rusty-rays-cli/src/main.rs
@@ -2,8 +2,8 @@ use clap::Parser;
 use std::path::PathBuf;
 use std::thread;
 
-use rusty_rays_core::logger::{error, info, shutdown_logger, LOG};
-use rusty_rays_core::{write_render_to_file, Model, Tracer};
+use rusty_rays_core::logger::{LOG, error, info, shutdown_logger};
+use rusty_rays_core::{Model, Tracer, write_render_to_file};
 
 use rusty_rays_core::CancellationToken;
 
@@ -114,7 +114,7 @@ fn install_cancel_handlers(cancel: CancellationToken) -> Option<std::thread::Joi
             info!(LOG, "received Ctrl+C (or Ctrl+Break). canceling render...");
             cancel_for_ctrlc.cancel();
         })
-            .expect("failed to set Ctrl+C handler");
+        .expect("failed to set Ctrl+C handler");
     }
 
     // Unix-only: also cancel on Ctrl+Z (SIGTSTP).

--- a/rusty-rays-cli/src/main.rs
+++ b/rusty-rays-cli/src/main.rs
@@ -1,8 +1,14 @@
 use clap::Parser;
 use std::path::PathBuf;
+use std::thread;
 
-use rusty_rays_core::logger::{LOG, error, info, shutdown_logger};
-use rusty_rays_core::{Model, Tracer, write_render_to_file};
+use rusty_rays_core::logger::{error, info, shutdown_logger, LOG};
+use rusty_rays_core::{write_render_to_file, CancellationToken, Model, Tracer};
+
+// Add this dependency in Cargo.toml:
+// signal-hook = "0.3"
+use signal_hook::consts::signal::{SIGINT, SIGTERM, SIGTSTP};
+use signal_hook::iterator::Signals;
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -14,6 +20,11 @@ struct Args {
     /// Path to the output file
     #[arg(short, long, default_value = "./render.bmp")]
     output_file: PathBuf,
+
+    /// Number of progress blocks across the whole render.
+    /// Example: 10 => ~10% steps, 100 => ~1% steps, 0 => disable progress events/log blocks.
+    #[arg(long, default_value_t = 10)]
+    progress_blocks: usize,
 }
 
 fn main() {
@@ -35,7 +46,55 @@ fn main() {
         Ok(model) => {
             info!(LOG, "initialized model from input file");
             let tracer = Tracer::new(model);
-            let maybe_raw_pixel_colors = tracer.render();
+
+            // Cancellation token shared with signal handler.
+            let cancel = CancellationToken::default();
+
+            // Spawn a small signal-listener thread that cancels the render on Ctrl+Z (SIGTSTP),
+            // Ctrl+C (SIGINT), or termination (SIGTERM).
+            let cancel_for_signals = cancel.clone();
+            let signals_thread = thread::spawn(move || {
+                // Note: catching SIGTSTP prevents the default "suspend process" behavior.
+                let mut signals =
+                    Signals::new([SIGTSTP, SIGINT, SIGTERM]).expect("failed to register signals");
+                for sig in signals.forever() {
+                    match sig {
+                        SIGTSTP => {
+                            info!(LOG, "received Ctrl+Z (SIGTSTP). canceling render...");
+                        }
+                        SIGINT => {
+                            info!(LOG, "received Ctrl+C (SIGINT). canceling render...");
+                        }
+                        SIGTERM => {
+                            info!(LOG, "received SIGTERM. canceling render...");
+                        }
+                        _ => {}
+                    }
+                    cancel_for_signals.cancel();
+                    break;
+                }
+            });
+
+            // Run the render on a background thread so main can respond to signals and then
+            // exit only after render returns.
+            let progress_blocks = args.progress_blocks;
+            let cancel_for_render = cancel.clone();
+
+            let render_thread = thread::spawn(move || {
+                // No event channel in the CLI for now; core will still log progress blocks itself.
+                tracer.render(Some(cancel_for_render), None, Some(progress_blocks))
+            });
+
+            // Wait for render to finish (either completed or canceled)
+            let maybe_raw_pixel_colors = render_thread.join().unwrap_or_else(|error| {
+                Err(rusty_rays_core::RenderError(
+                    "render thread panicked".to_string(),
+                ))
+            });
+
+            // Make sure the signal thread stops (if render finished normally, we still want to exit cleanly)
+            // Dropping the process will end it anyway, but joining avoids dangling threads in some environments.
+            let _ = signals_thread.join();
 
             match maybe_raw_pixel_colors {
                 Ok(raw_pixel_colors) => {
@@ -50,7 +109,12 @@ fn main() {
                     }
                 }
                 Err(error) => {
-                    error!(LOG, "{}", error);
+                    // Your core returns RenderError("canceled") on cancel — treat that as a normal exit.
+                    if error.to_string().contains("canceled") {
+                        info!(LOG, "render canceled. exiting.");
+                    } else {
+                        error!(LOG, "{}", error);
+                    }
                 }
             }
         }

--- a/rusty-rays-cli/src/main.rs
+++ b/rusty-rays-cli/src/main.rs
@@ -5,10 +5,11 @@ use std::thread;
 use rusty_rays_core::logger::{error, info, shutdown_logger, LOG};
 use rusty_rays_core::{write_render_to_file, Model, Tracer};
 
-// Add this dependency in Cargo.toml:
-// signal-hook = "0.3"
 use rusty_rays_core::CancellationToken;
-use signal_hook::consts::signal::{SIGINT, SIGTERM, SIGTSTP};
+
+#[cfg(unix)]
+use signal_hook::consts::signal::SIGTSTP;
+#[cfg(unix)]
 use signal_hook::iterator::Signals;
 
 #[derive(Parser, Debug)]
@@ -48,36 +49,13 @@ fn main() {
             info!(LOG, "initialized model from input file");
             let tracer = Tracer::new(model);
 
-            // Cancellation token shared with signal handler.
+            // Cancellation token shared with handlers.
             let cancel = CancellationToken::default();
 
-            // Spawn a small signal-listener thread that cancels the render on Ctrl+Z (SIGTSTP),
-            // Ctrl+C (SIGINT), or termination (SIGTERM).
-            let cancel_for_signals = cancel.clone();
-            let signals_thread = thread::spawn(move || {
-                // Note: catching SIGTSTP prevents the default "suspend process" behavior.
-                let mut signals =
-                    Signals::new([SIGTSTP, SIGINT, SIGTERM]).expect("failed to register signals");
-                for sig in signals.forever() {
-                    match sig {
-                        SIGTSTP => {
-                            info!(LOG, "received Ctrl+Z (SIGTSTP). canceling render...");
-                        }
-                        SIGINT => {
-                            info!(LOG, "received Ctrl+C (SIGINT). canceling render...");
-                        }
-                        SIGTERM => {
-                            info!(LOG, "received SIGTERM. canceling render...");
-                        }
-                        _ => {}
-                    }
-                    cancel_for_signals.cancel();
-                    break;
-                }
-            });
+            // Install signal/console handlers.
+            let signals_thread = install_cancel_handlers(cancel.clone());
 
-            // Run the render on a background thread so main can respond to signals and then
-            // exit only after render returns.
+            // Run the render on a background thread so main can cleanly wait for completion/cancel.
             let progress_blocks = args.progress_blocks;
             let cancel_for_render = cancel.clone();
 
@@ -87,15 +65,16 @@ fn main() {
             });
 
             // Wait for render to finish (either completed or canceled)
-            let maybe_raw_pixel_colors = render_thread.join().unwrap_or_else(|error| {
+            let maybe_raw_pixel_colors = render_thread.join().unwrap_or_else(|_error| {
                 Err(rusty_rays_core::RenderError(
                     "render thread panicked".to_string(),
                 ))
             });
 
-            // Make sure the signal thread stops (if render finished normally, we still want to exit cleanly)
-            // Dropping the process will end it anyway, but joining avoids dangling threads in some environments.
-            let _ = signals_thread.join();
+            // If we spawned a Unix SIGTSTP listener thread, join it so we don't leave a dangling thread.
+            if let Some(t) = signals_thread {
+                let _ = t.join();
+            }
 
             match maybe_raw_pixel_colors {
                 Ok(raw_pixel_colors) => {
@@ -125,4 +104,36 @@ fn main() {
     }
 
     shutdown_logger();
+}
+
+fn install_cancel_handlers(cancel: CancellationToken) -> Option<std::thread::JoinHandle<()>> {
+    // Cross-platform Ctrl+C (and Ctrl+Break on Windows).
+    {
+        let cancel_for_ctrlc = cancel.clone();
+        ctrlc::set_handler(move || {
+            info!(LOG, "received Ctrl+C (or Ctrl+Break). canceling render...");
+            cancel_for_ctrlc.cancel();
+        })
+            .expect("failed to set Ctrl+C handler");
+    }
+
+    // Unix-only: also cancel on Ctrl+Z (SIGTSTP).
+    #[cfg(unix)]
+    {
+        let cancel_for_sigstp = cancel.clone();
+        return Some(thread::spawn(move || {
+            // Catching SIGTSTP prevents the default "suspend process" behavior.
+            let mut signals = Signals::new([SIGTSTP]).expect("failed to register SIGTSTP");
+            for _sig in signals.forever() {
+                info!(LOG, "received Ctrl+Z (SIGTSTP). canceling render...");
+                cancel_for_sigstp.cancel();
+                break;
+            }
+        }));
+    }
+
+    #[cfg(not(unix))]
+    {
+        None
+    }
 }

--- a/rusty-rays-core/src/lib.rs
+++ b/rusty-rays-core/src/lib.rs
@@ -5,10 +5,10 @@ use std::path::PathBuf;
 use std::sync::OnceLock;
 
 pub use tracer::{
-    Color, Cone, Coords, Fov, Model, Plane, PlaneCoords2D, Polygon, Screen, Sphere, Surface,
-    Tracer, Triangle,
+    CancellationToken, Color, Cone, Coords, Fov, Model, Plane, PlaneCoords2D, Polygon, RenderError,
+    RenderEvent, Screen, Sphere, Surface, Tracer, Triangle,
 };
-pub use utils::{Config, logger, write_render_to_file, write_render_to_image_buffer};
+pub use utils::{logger, write_render_to_file, write_render_to_image_buffer, Config};
 pub use uuid::Uuid;
 
 /// Override the default config directory. This the directory where the config file is stored,

--- a/rusty-rays-core/src/lib.rs
+++ b/rusty-rays-core/src/lib.rs
@@ -8,7 +8,7 @@ pub use tracer::{
     CancellationToken, Color, Cone, Coords, Fov, Model, Plane, PlaneCoords2D, Polygon, RenderError,
     RenderEvent, Screen, Sphere, Surface, Tracer, Triangle,
 };
-pub use utils::{logger, write_render_to_file, write_render_to_image_buffer, Config};
+pub use utils::{Config, logger, write_render_to_file, write_render_to_image_buffer};
 pub use uuid::Uuid;
 
 /// Override the default config directory. This the directory where the config file is stored,

--- a/rusty-rays-core/src/tracer/camera.rs
+++ b/rusty-rays-core/src/tracer/camera.rs
@@ -1,4 +1,4 @@
-use crate::logger::{debug, trace, LOG};
+use crate::logger::{LOG, debug, trace};
 use crate::tracer::misc_types::Ray;
 use crate::{Coords, Model};
 use std::f64;

--- a/rusty-rays-core/src/tracer/misc_types.rs
+++ b/rusty-rays-core/src/tracer/misc_types.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-
+use std::sync::{atomic, Arc};
 use uuid::Uuid;
 
 use crate::tracer::Color;
@@ -119,4 +119,24 @@ pub struct Intersection {
     pub position: Coords,
     pub surface_normal_at_intersection: Coords,
     pub intersected_primitive_uuid: Uuid,
+}
+
+#[derive(Clone, Default)]
+pub struct CancellationToken(Arc<atomic::AtomicBool>);
+
+impl CancellationToken {
+    pub fn cancel(&self) {
+        self.0.store(true, atomic::Ordering::Relaxed);
+    }
+    pub fn is_canceled(&self) -> bool {
+        self.0.load(atomic::Ordering::Relaxed)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum RenderEvent {
+    Progress { percent: u8 },
+    Finished { millis: u128 },
+    Canceled { millis: u128 },
+    Error(String),
 }

--- a/rusty-rays-core/src/tracer/misc_types.rs
+++ b/rusty-rays-core/src/tracer/misc_types.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::sync::{atomic, Arc};
+use std::sync::{Arc, atomic};
 use uuid::Uuid;
 
 use crate::tracer::Color;

--- a/rusty-rays-core/src/tracer/mod.rs
+++ b/rusty-rays-core/src/tracer/mod.rs
@@ -155,7 +155,7 @@ impl Tracer {
                     }
 
                     // Progress emission based on configured blocks.
-                    if ray_index != 0 && (ray_index % block_size == 0) {
+                    if ray_index % block_size == 0 {
                         let block_idx = _progress_block_counter_arc_clone
                             .fetch_add(1, atomic::Ordering::Relaxed)
                             + 1;

--- a/rusty-rays-core/src/tracer/mod.rs
+++ b/rusty-rays-core/src/tracer/mod.rs
@@ -3,7 +3,6 @@ use crate::utils::logger::{debug, error, info, trace, warn, LOG};
 use crate::utils::Config;
 use bvh::Bvh;
 pub use coords::Coords;
-use misc_types::Ray;
 pub use misc_types::{Fov, Screen, Surface};
 pub use model::Model;
 pub use plane_coords_2d::PlaneCoords2D;
@@ -14,7 +13,7 @@ use primitives::Primitive;
 pub use primitives::Sphere;
 pub use primitives::Triangle;
 pub use shader::Color;
-use std::sync::{atomic, Arc, Mutex};
+use std::sync::{atomic, mpsc, Arc, Mutex};
 use std::time::SystemTime;
 use std::{f64, fmt, thread};
 
@@ -27,6 +26,25 @@ mod plane_coords_2d;
 mod primitives;
 mod rayshade4_file_parser;
 mod shader;
+
+#[derive(Clone, Default)]
+pub struct CancellationToken(Arc<atomic::AtomicBool>);
+impl CancellationToken {
+    pub fn cancel(&self) {
+        self.0.store(true, atomic::Ordering::Relaxed);
+    }
+    pub fn is_canceled(&self) -> bool {
+        self.0.load(atomic::Ordering::Relaxed)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum RenderEvent {
+    Progress { percent: u8 },
+    Finished { millis: u128 },
+    Canceled { millis: u128 },
+    Error(String),
+}
 
 #[derive(Debug)]
 pub struct Tracer {
@@ -62,10 +80,21 @@ impl Tracer {
         Self { model, bvh, camera }
     }
 
-    pub fn render(&self) -> Result<Vec<Vec<Color>>, RenderError> {
+    /// Optional cancellation token, optional event sender, optional progress blocks.
+    ///
+    /// `progress_blocks` controls how many progress events are emitted across the whole render:
+    /// - Some(10) => ~10% increments
+    /// - Some(100) => ~1% increments
+    /// - Some(0) or None => disabled (no progress events; logging still occurs only for other messages)
+    pub fn render(
+        &self,
+        cancel: Option<CancellationToken>,
+        events: Option<mpsc::Sender<RenderEvent>>,
+        num_progress_blocks: Option<usize>,
+    ) -> Result<Vec<Vec<Color>>, RenderError> {
         info!(LOG, "rendering model");
         let self_arc = Arc::new(self.clone());
-        Self::_render(self_arc)
+        Self::_render(self_arc, cancel, events, num_progress_blocks)
     }
 
     pub fn get_intersected_uuid_by_pixel_pos(
@@ -86,7 +115,12 @@ impl Tracer {
         }
     }
 
-    fn _render(self: Arc<Self>) -> Result<Vec<Vec<Color>>, RenderError> {
+    fn _render(
+        self: Arc<Self>,
+        cancel: Option<CancellationToken>,
+        event_tx: Option<mpsc::Sender<RenderEvent>>,
+        num_progress_blocks: Option<usize>,
+    ) -> Result<Vec<Vec<Color>>, RenderError> {
         let max_threads = Config::get().max_render_threads;
         let num_physical_cores = num_cpus::get_physical();
         let num_threads = max_threads.min(num_physical_cores).max(1);
@@ -94,7 +128,12 @@ impl Tracer {
 
         let total_pixels = self.model.screen.width * self.model.screen.height;
         let ray_counter_arc = Arc::new(atomic::AtomicUsize::new(0));
-        let ten_percent_arc = Arc::new((total_pixels / 10).max(1));
+
+        // Progress configuration (optional)
+        let _num_progress_blocks = num_progress_blocks.unwrap_or(10);
+        let block_size = (total_pixels / _num_progress_blocks).max(1);
+
+        // Counts how many blocks have been emitted (so only one thread emits each block once).
         let progress_block_counter_arc = Arc::new(atomic::AtomicUsize::new(0));
 
         let image_data_arc = Arc::new(Mutex::new(vec![
@@ -103,42 +142,69 @@ impl Tracer {
         ]));
         let self_arc = Arc::new(self.clone());
 
+        // If caller didn't provide a token, use a default "never canceled" token.
+        let cancel = cancel.unwrap_or_default();
+
         let start_time = SystemTime::now();
         for thread_num in 0..num_threads {
             // these arc clones do not clone the underlying data
             let _image_data_arc_clone = Arc::clone(&image_data_arc);
             let _self_arc_clone = Arc::clone(&self_arc);
             let _ray_counter_arc_clone = Arc::clone(&ray_counter_arc);
-            let _ten_percent_arc_clone = Arc::clone(&ten_percent_arc);
             let _progress_block_counter_arc_clone = Arc::clone(&progress_block_counter_arc);
+
+            let cancel_clone = cancel.clone();
+            let events_clone = event_tx.clone();
 
             let handle = thread::spawn(move || {
                 info!(LOG, "starting render thread #{}", thread_num);
                 let mut thread_rendered_pixels: Vec<((usize, usize), Color)> = vec![];
 
                 loop {
+                    if cancel_clone.is_canceled() {
+                        break;
+                    }
+
                     let ray_index = _ray_counter_arc_clone.fetch_add(1, atomic::Ordering::Relaxed);
                     trace!(LOG, "thread {} rendering ray #{}", thread_num, ray_index);
-
-                    if ray_index != 0 && ray_index.is_multiple_of(*_ten_percent_arc_clone) {
-                        let progress_block = _progress_block_counter_arc_clone
-                            .fetch_add(1, atomic::Ordering::Relaxed)
-                            + 1; // fetch_add() returns the previous value, not the new sum
-                        info!(LOG, "rendering {}% complete", progress_block * 10);
-                    }
 
                     if ray_index >= total_pixels {
                         break;
                     }
 
+                    // Progress emission based on configured blocks.
+                    if ray_index != 0 && (ray_index % block_size == 0) {
+                        let block_idx = _progress_block_counter_arc_clone
+                            .fetch_add(1, atomic::Ordering::Relaxed)
+                            + 1;
+
+                        // Clamp to avoid emitting past 100% due to rounding.
+                        if block_idx <= _num_progress_blocks {
+                            let percent = ((block_idx * 100) / _num_progress_blocks).min(100) as u8;
+
+                            info!(LOG, "rendering {}% complete", percent);
+
+                            if let Some(tx) = &events_clone {
+                                let _ = tx.send(RenderEvent::Progress { percent });
+                            }
+                        }
+                    }
+
                     let i = ray_index % _self_arc_clone.model.screen.width;
                     let j = ray_index / _self_arc_clone.model.screen.width;
+
+                    if cancel_clone.is_canceled() {
+                        break;
+                    }
+
                     let ray =
                         &_self_arc_clone
                             .camera
                             .calc_ray_definition(i, j, &_self_arc_clone.model);
+
                     let pixel_color =
                         shader::process_ray(0, ray, &_self_arc_clone.model, &_self_arc_clone.bvh);
+
                     thread_rendered_pixels.push(((ray.i, ray.j), pixel_color));
                 }
 
@@ -154,6 +220,11 @@ impl Tracer {
                             "thread {} encountered poisoned data error when trying to write pixel colors to image data",
                             thread_num,
                         );
+                        if let Some(tx) = &events_clone {
+                            let _ = tx.send(RenderEvent::Error(
+                                "poisoned mutex while writing image data".to_string(),
+                            ));
+                        }
                     }
                 }
             });
@@ -174,25 +245,46 @@ impl Tracer {
             }
         }
 
+        let stop_time = SystemTime::now();
+        let elapsed_millis = stop_time
+            .duration_since(start_time)
+            .map(|d| d.as_millis())
+            .unwrap_or(0);
+
         if thread_error {
+            if let Some(tx) = &event_tx {
+                let _ = tx.send(RenderEvent::Error(
+                    "render threads did not exit properly".to_string(),
+                ));
+            }
             return Err(RenderError(
                 "render threads did not exit properly".to_string(),
             ));
         }
 
+        if cancel.is_canceled() {
+            if let Some(tx) = &event_tx {
+                let _ = tx.send(RenderEvent::Canceled {
+                    millis: elapsed_millis,
+                });
+            }
+            return Err(RenderError("canceled".to_string()));
+        }
+
+        if let Some(tx) = &event_tx {
+            let _ = tx.send(RenderEvent::Finished {
+                millis: elapsed_millis,
+            });
+        }
+
         match Arc::try_unwrap(image_data_arc) {
             Ok(image_data_mutex) => match image_data_mutex.into_inner() {
                 Ok(raw_image_data) => {
-                    let stop_time = SystemTime::now();
-                    let maybe_duration = stop_time.duration_since(start_time);
-                    if let Ok(elapsed_time) = maybe_duration {
-                        info!(
-                            LOG,
-                            "render completed in {} seconds",
-                            elapsed_time.as_millis() as f64 / 1000.0
-                        )
-                    }
-
+                    info!(
+                        LOG,
+                        "render completed in {} seconds",
+                        elapsed_millis as f64 / 1000.0
+                    );
                     Ok(raw_image_data)
                 }
                 Err(error) => Err(RenderError(format!(
@@ -208,7 +300,7 @@ impl Tracer {
 }
 
 #[derive(Debug)]
-pub struct RenderError(String);
+pub struct RenderError(pub String);
 
 impl fmt::Display for RenderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/rusty-rays-core/src/tracer/mod.rs
+++ b/rusty-rays-core/src/tracer/mod.rs
@@ -1,6 +1,6 @@
 use crate::tracer::camera::Camera;
-use crate::utils::logger::{debug, error, info, trace, warn, LOG};
 use crate::utils::Config;
+use crate::utils::logger::{LOG, debug, error, info, trace, warn};
 use bvh::Bvh;
 pub use coords::Coords;
 pub use misc_types::{CancellationToken, RenderEvent};
@@ -14,7 +14,7 @@ use primitives::Primitive;
 pub use primitives::Sphere;
 pub use primitives::Triangle;
 pub use shader::Color;
-use std::sync::{atomic, mpsc, Arc, Mutex};
+use std::sync::{Arc, Mutex, atomic, mpsc};
 use std::time::SystemTime;
 use std::{f64, fmt, thread};
 
@@ -155,7 +155,7 @@ impl Tracer {
                     }
 
                     // Progress emission based on configured blocks.
-                    if ray_index % block_size == 0 {
+                    if ray_index.is_multiple_of(block_size) {
                         let block_idx = _progress_block_counter_arc_clone
                             .fetch_add(1, atomic::Ordering::Relaxed)
                             + 1;
@@ -244,12 +244,12 @@ impl Tracer {
             ));
         }
 
-        if cancel.is_canceled() {
-            if let Some(tx) = &event_tx {
-                let _ = tx.send(RenderEvent::Canceled {
-                    millis: elapsed_millis,
-                });
-            }
+        if cancel.is_canceled()
+            && let Some(tx) = &event_tx
+        {
+            let _ = tx.send(RenderEvent::Canceled {
+                millis: elapsed_millis,
+            });
         }
 
         if let Some(tx) = &event_tx {

--- a/rusty-rays-core/src/tracer/mod.rs
+++ b/rusty-rays-core/src/tracer/mod.rs
@@ -3,6 +3,7 @@ use crate::utils::logger::{debug, error, info, trace, warn, LOG};
 use crate::utils::Config;
 use bvh::Bvh;
 pub use coords::Coords;
+pub use misc_types::{CancellationToken, RenderEvent};
 pub use misc_types::{Fov, Screen, Surface};
 pub use model::Model;
 pub use plane_coords_2d::PlaneCoords2D;
@@ -26,25 +27,6 @@ mod plane_coords_2d;
 mod primitives;
 mod rayshade4_file_parser;
 mod shader;
-
-#[derive(Clone, Default)]
-pub struct CancellationToken(Arc<atomic::AtomicBool>);
-impl CancellationToken {
-    pub fn cancel(&self) {
-        self.0.store(true, atomic::Ordering::Relaxed);
-    }
-    pub fn is_canceled(&self) -> bool {
-        self.0.load(atomic::Ordering::Relaxed)
-    }
-}
-
-#[derive(Clone, Debug)]
-pub enum RenderEvent {
-    Progress { percent: u8 },
-    Finished { millis: u128 },
-    Canceled { millis: u128 },
-    Error(String),
-}
 
 #[derive(Debug)]
 pub struct Tracer {
@@ -89,12 +71,12 @@ impl Tracer {
     pub fn render(
         &self,
         cancel: Option<CancellationToken>,
-        events: Option<mpsc::Sender<RenderEvent>>,
+        events_tx: Option<mpsc::Sender<RenderEvent>>,
         num_progress_blocks: Option<usize>,
     ) -> Result<Vec<Vec<Color>>, RenderError> {
         info!(LOG, "rendering model");
         let self_arc = Arc::new(self.clone());
-        Self::_render(self_arc, cancel, events, num_progress_blocks)
+        Self::_render(self_arc, cancel, events_tx, num_progress_blocks)
     }
 
     pub fn get_intersected_uuid_by_pixel_pos(
@@ -154,7 +136,7 @@ impl Tracer {
             let _progress_block_counter_arc_clone = Arc::clone(&progress_block_counter_arc);
 
             let cancel_clone = cancel.clone();
-            let events_clone = event_tx.clone();
+            let events_tx_clone = event_tx.clone();
 
             let handle = thread::spawn(move || {
                 info!(LOG, "starting render thread #{}", thread_num);
@@ -184,7 +166,7 @@ impl Tracer {
 
                             info!(LOG, "rendering {}% complete", percent);
 
-                            if let Some(tx) = &events_clone {
+                            if let Some(tx) = &events_tx_clone {
                                 let _ = tx.send(RenderEvent::Progress { percent });
                             }
                         }
@@ -220,7 +202,7 @@ impl Tracer {
                             "thread {} encountered poisoned data error when trying to write pixel colors to image data",
                             thread_num,
                         );
-                        if let Some(tx) = &events_clone {
+                        if let Some(tx) = &events_tx_clone {
                             let _ = tx.send(RenderEvent::Error(
                                 "poisoned mutex while writing image data".to_string(),
                             ));
@@ -268,7 +250,6 @@ impl Tracer {
                     millis: elapsed_millis,
                 });
             }
-            return Err(RenderError("canceled".to_string()));
         }
 
         if let Some(tx) = &event_tx {

--- a/rusty-rays-core/src/tracer/mod.rs
+++ b/rusty-rays-core/src/tracer/mod.rs
@@ -1,6 +1,6 @@
 use crate::tracer::camera::Camera;
+use crate::utils::logger::{debug, error, info, trace, warn, LOG};
 use crate::utils::Config;
-use crate::utils::logger::{LOG, debug, error, info, trace, warn};
 use bvh::Bvh;
 pub use coords::Coords;
 use misc_types::Ray;
@@ -14,7 +14,7 @@ use primitives::Primitive;
 pub use primitives::Sphere;
 pub use primitives::Triangle;
 pub use shader::Color;
-use std::sync::{Arc, Mutex, atomic};
+use std::sync::{atomic, Arc, Mutex};
 use std::time::SystemTime;
 use std::{f64, fmt, thread};
 
@@ -32,7 +32,6 @@ mod shader;
 pub struct Tracer {
     model: Model,
     bvh: Bvh,
-    primary_rays: Vec<Ray>,
     camera: Camera,
 }
 
@@ -40,7 +39,6 @@ impl Clone for Tracer {
     fn clone(&self) -> Self {
         Tracer {
             model: self.model.clone(),
-            primary_rays: self.primary_rays.clone(),
             bvh: self.bvh.clone(),
             camera: self.camera.clone(),
         }
@@ -54,7 +52,6 @@ impl Tracer {
             "initializing renderer. calculating primary ray definitions and bvh"
         );
         let camera = Camera::new(&model);
-        let primary_rays = Self::calculate_primary_rays(&model, &camera);
 
         // Collect all primitives into a vector for Bvh construction
         let primitives_for_bvh: Vec<Box<dyn Primitive>> =
@@ -62,12 +59,7 @@ impl Tracer {
         let mut bvh = Bvh::new();
         bvh.build(primitives_for_bvh);
 
-        Self {
-            model,
-            primary_rays,
-            bvh,
-            camera,
-        }
+        Self { model, bvh, camera }
     }
 
     pub fn render(&self) -> Result<Vec<Vec<Color>>, RenderError> {
@@ -100,8 +92,9 @@ impl Tracer {
         let num_threads = max_threads.min(num_physical_cores).max(1);
         let mut thread_handles = vec![];
 
+        let total_pixels = self.model.screen.width * self.model.screen.height;
         let ray_counter_arc = Arc::new(atomic::AtomicUsize::new(0));
-        let ten_percent_arc = Arc::new((self.primary_rays.len() / 10).max(1));
+        let ten_percent_arc = Arc::new((total_pixels / 10).max(1));
         let progress_block_counter_arc = Arc::new(atomic::AtomicUsize::new(0));
 
         let image_data_arc = Arc::new(Mutex::new(vec![
@@ -134,11 +127,16 @@ impl Tracer {
                         info!(LOG, "rendering {}% complete", progress_block * 10);
                     }
 
-                    if ray_index >= _self_arc_clone.primary_rays.len() {
+                    if ray_index >= total_pixels {
                         break;
                     }
 
-                    let ray = &_self_arc_clone.primary_rays[ray_index];
+                    let i = ray_index % _self_arc_clone.model.screen.width;
+                    let j = ray_index / _self_arc_clone.model.screen.width;
+                    let ray =
+                        &_self_arc_clone
+                            .camera
+                            .calc_ray_definition(i, j, &_self_arc_clone.model);
                     let pixel_color =
                         shader::process_ray(0, ray, &_self_arc_clone.model, &_self_arc_clone.bvh);
                     thread_rendered_pixels.push(((ray.i, ray.j), pixel_color));
@@ -206,19 +204,6 @@ impl Tracer {
                 "an asynchronous resource sharing error occurred".to_string(),
             )),
         }
-    }
-
-    fn calculate_primary_rays(model: &Model, camera: &Camera) -> Vec<Ray> {
-        let mut rays: Vec<Ray> = Vec::new();
-
-        for i in 0..model.screen.height {
-            for j in 0..model.screen.width {
-                let ray = camera.calc_ray_definition(i, j, model);
-                rays.push(ray);
-            }
-        }
-
-        rays
     }
 }
 

--- a/rusty-rays-core/src/tracer/rayshade4_file_parser/parse_triangle.rs
+++ b/rusty-rays-core/src/tracer/rayshade4_file_parser/parse_triangle.rs
@@ -10,7 +10,7 @@ use crate::tracer::rayshade4_file_parser::{
     GetNextLineClosure, NextIfClosure, NextLine, SCENE_DATA_KEYWORDS,
 };
 use crate::tracer::Coords;
-use crate::utils::logger::{debug, trace, LOG};
+use crate::utils::logger::{trace, LOG};
 
 pub fn process_triangle(
     determine_next_line_iter: &mut GetNextLineClosure,

--- a/rusty-rays-core/src/tracer/rayshade4_file_parser/parse_triangle.rs
+++ b/rusty-rays-core/src/tracer/rayshade4_file_parser/parse_triangle.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::iter::Peekable;
 use std::str::SplitWhitespace;
 
+use crate::tracer::Coords;
 use crate::tracer::misc_types::Surface;
 use crate::tracer::model::ModelError;
 use crate::tracer::model::ModelError::FailedToParseInputFile;
@@ -9,8 +10,7 @@ use crate::tracer::primitives::Triangle;
 use crate::tracer::rayshade4_file_parser::{
     GetNextLineClosure, NextIfClosure, NextLine, SCENE_DATA_KEYWORDS,
 };
-use crate::tracer::Coords;
-use crate::utils::logger::{trace, LOG};
+use crate::utils::logger::{LOG, trace};
 
 pub fn process_triangle(
     determine_next_line_iter: &mut GetNextLineClosure,

--- a/rusty-rays-desktop/package-lock.json
+++ b/rusty-rays-desktop/package-lock.json
@@ -112,7 +112,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -394,6 +393,7 @@
       "integrity": "sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "commander": "^5.0.0",
         "glob": "^7.1.6",
@@ -412,6 +412,7 @@
       "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -423,6 +424,7 @@
       "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -657,6 +659,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -678,6 +681,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -694,6 +698,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -708,6 +713,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -3686,7 +3692,6 @@
       "integrity": "sha512-keKxkZMqnDicuvFoJbzrhbtdLSPhj/rZThDlKWCDbgXmUg0rEUFtRssDXKYmtXluZlIqiC5VqkCgRwzuyLHKHw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3697,7 +3702,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3783,7 +3787,6 @@
       "integrity": "sha512-tK3GPFWbirvNgsNKto+UmB/cRtn6TZfyw0D6IKrW55n6Vbs7KJoZtI//kpTKzE/DUmmnAFD8/Ca46s7Obs92/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.4",
         "@typescript-eslint/types": "8.46.4",
@@ -4329,7 +4332,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4393,7 +4395,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5078,7 +5079,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -5903,7 +5903,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-env": {
       "version": "10.1.0",
@@ -6140,7 +6141,6 @@
       "integrity": "sha512-59CAAjAhTaIMCN8y9kD573vDkxbs1uhDcrFLHSgutYdPcGOU35Rf95725snvzEOy4BFB7+eLJ8djCNPmGwG67w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.0.12",
         "builder-util": "26.0.11",
@@ -6463,6 +6463,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -6483,6 +6484,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -6632,7 +6634,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -6751,7 +6752,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9539,6 +9539,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -9556,6 +9557,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -9687,7 +9689,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9718,7 +9719,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9740,7 +9740,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -9905,8 +9904,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -10615,6 +10613,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -10679,6 +10678,7 @@
       "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -10700,6 +10700,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -10714,6 +10715,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -10782,7 +10784,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10947,7 +10948,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11030,7 +11030,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.0"
       },
@@ -11201,7 +11200,6 @@
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -11779,7 +11777,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11953,7 +11950,6 @@
       "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/rusty-rays-desktop/package-lock.json
+++ b/rusty-rays-desktop/package-lock.json
@@ -13,6 +13,7 @@
         "@headlessui/react": "^2.2.9",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
+        "@radix-ui/react-progress": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-visually-hidden": "^1.2.4",
         "@reduxjs/toolkit": "^2.10.1",
@@ -2441,6 +2442,68 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.8.tgz",
+      "integrity": "sha512-+gISHcSPUJ7ktBy9RnTqbdKW78bcGke3t6taawyZ71pio1JewwGSJizycs7rLhGTvMJYCQB1DBK4KQsxs7U8dA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-context": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.3.tgz",
+      "integrity": "sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+      "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/rusty-rays-desktop/package.json
+++ b/rusty-rays-desktop/package.json
@@ -49,6 +49,7 @@
     "@headlessui/react": "^2.2.9",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-progress": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-visually-hidden": "^1.2.4",
     "@reduxjs/toolkit": "^2.10.1",

--- a/rusty-rays-desktop/src/ipc/shared/index.ts
+++ b/rusty-rays-desktop/src/ipc/shared/index.ts
@@ -31,7 +31,8 @@ function toIpcError(error: unknown, altMsg: string) {
  */
 type RenderStatus = {
   tracerInstanceUuid?: string;
-  renderInProgress: boolean;
+  renderProgressPercentage?: number;
+  writingImage: boolean;
   renderErrorMsg?: string;
   renderImageAvailable: boolean;
 };

--- a/rusty-rays-desktop/src/renderer/components/buttons/CloseModelButton.tsx
+++ b/rusty-rays-desktop/src/renderer/components/buttons/CloseModelButton.tsx
@@ -13,8 +13,8 @@ const CloseModelButton: React.FC = () => {
   const [errorMessage, setErrorMessage] = useState<string>('');
 
   const maybeRenderInProgress = useMemo(
-    () => renderStatus?.renderInProgress || fetchingRenderStatus,
-    [fetchingRenderStatus, renderStatus?.renderInProgress],
+    () => !!renderStatus?.renderProgressPercentage || fetchingRenderStatus,
+    [fetchingRenderStatus, renderStatus?.renderProgressPercentage],
   );
 
   const onClickClose = useCallback(() => {

--- a/rusty-rays-desktop/src/renderer/components/layout/RenderedImageLayout.tsx
+++ b/rusty-rays-desktop/src/renderer/components/layout/RenderedImageLayout.tsx
@@ -1,4 +1,4 @@
-import { Alert, Card, Dialog, Loader } from '@/retro-ui-lib';
+import { Alert, Card, Dialog, Loader, Progress } from '@/retro-ui-lib';
 import { RenderedImageCanvasWidget } from '@/components';
 import React, { useCallback, useEffect, useState } from 'react';
 
@@ -51,7 +51,7 @@ const RenderedImageLayout: React.FC = () => {
   useEffect(() => {
     const execute = async () => {
       if (renderStatus && tracerInstanceUuid) {
-        if (renderStatus.renderInProgress) {
+        if (renderStatus.renderProgressPercentage) {
           setPollRenderProgress(true);
         } else if (renderStatus.renderImageAvailable) {
           try {
@@ -147,15 +147,30 @@ const RenderedImageLayout: React.FC = () => {
   return (
     <Card className="flex-1 min-h-0">
       <Card.Content className="p-2 w-full h-full items-center justify-center">
-        {!renderStatus || renderStatus.renderInProgress || !imageData ? (
+        {!renderStatus ||
+        renderStatus.renderProgressPercentage ||
+        !imageData ? (
           <div className="flex flex-col h-full w-full items-center justify-center bg-muted">
             <Alert className="flex flex-col lg:max-w-2/3 max-w-1/2">
-              <Alert.Title className="text-center">
-                Render in progress...
-              </Alert.Title>
-              <div className="flex items-center justify-center pt-2">
-                <Loader count={10} delayStep={60} />
-              </div>
+              {renderStatus?.writingImage ? (
+                <>
+                  <Alert.Title className="text-center">
+                    Encoding image...
+                  </Alert.Title>
+                  <div className="flex items-center justify-center pt-2">
+                    <Loader count={10} delayStep={60} />
+                  </div>
+                </>
+              ) : (
+                <>
+                  <Alert.Title className="text-center">
+                    Render in progress...
+                  </Alert.Title>
+                  <div className="flex items-center justify-center pt-2">
+                    <Progress value={renderStatus?.renderProgressPercentage} />
+                  </div>
+                </>
+              )}
             </Alert>
           </div>
         ) : (

--- a/rusty-rays-desktop/src/renderer/components/layout/RenderedImageLayout.tsx
+++ b/rusty-rays-desktop/src/renderer/components/layout/RenderedImageLayout.tsx
@@ -37,8 +37,10 @@ const RenderedImageLayout: React.FC = () => {
   const { data: polygonsMap } = useGetAllPolygonsQuery(null, {
     skip: !tracerInstanceUuid || tracerInstanceUuidLoading,
   });
-  const [triggerLoadRenderImage, { error: loadRenderImageError }] =
-    useLazyLoadRenderImageQuery();
+  const [
+    triggerLoadRenderImage,
+    { isLoading: loadingRenderImage, error: loadRenderImageError },
+  ] = useLazyLoadRenderImageQuery();
   const [triggerRender] = useRenderMutation();
   const [triggerGetIntersectedUuid] =
     useLazyGetIntersectedObjectByPixelPosQuery();
@@ -163,12 +165,28 @@ const RenderedImageLayout: React.FC = () => {
                 </>
               ) : (
                 <>
-                  <Alert.Title className="text-center">
-                    Render in progress...
-                  </Alert.Title>
-                  <div className="flex items-center justify-center pt-2">
-                    <Progress value={renderStatus?.renderProgressPercentage} />
-                  </div>
+                  {loadingRenderImage ||
+                  !renderStatus?.renderProgressPercentage ? (
+                    <>
+                      <Alert.Title className="text-center">
+                        Loading...
+                      </Alert.Title>
+                      <div className="flex items-center justify-center pt-2">
+                        <Loader count={10} delayStep={60} />
+                      </div>
+                    </>
+                  ) : (
+                    <>
+                      <Alert.Title className="text-center">
+                        Render in progress...
+                      </Alert.Title>
+                      <div className="flex items-center justify-center pt-2">
+                        <Progress
+                          value={renderStatus.renderProgressPercentage || 0}
+                        />
+                      </div>
+                    </>
+                  )}
                 </>
               )}
             </Alert>

--- a/rusty-rays-desktop/src/renderer/components/widgets/RenderedImageCanvasWidget.tsx
+++ b/rusty-rays-desktop/src/renderer/components/widgets/RenderedImageCanvasWidget.tsx
@@ -158,23 +158,23 @@ const RenderedImageCanvasWidget: React.FC<RenderedImageCanvasWigetProps> = ({
   // Load image
   useEffect(() => {
     if (imageUrl) {
-      let cancelled = false;
+      let canceled = false;
       const img = new Image();
       img.decoding = 'async';
       img.onload = () => {
-        if (cancelled) return;
+        if (canceled) return;
         imgRef.current = img;
         draw(); // initial
       };
       img.onerror = () => {
-        if (cancelled) return;
+        if (canceled) return;
         imgRef.current = null;
         drawRectRef.current = null;
       };
       img.src = imageUrl;
 
       return () => {
-        cancelled = true;
+        canceled = true;
       };
     }
   }, [imageUrl]);

--- a/rusty-rays-desktop/src/renderer/retro-ui-lib/Progress.tsx
+++ b/rusty-rays-desktop/src/renderer/retro-ui-lib/Progress.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import * as React from "react";
+import * as ProgressPrimitive from "@radix-ui/react-progress";
+
+import { cn } from "@/retro-ui-lib/utils";
+
+const Progress = React.forwardRef<
+  React.ElementRef<typeof ProgressPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
+>(({ className, value, ...props }, ref) => (
+  <ProgressPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative h-4 w-full overflow-hidden bg-background border-2",
+      className,
+    )}
+    {...props}
+  >
+    <ProgressPrimitive.Indicator
+      className="h-full w-full flex-1 bg-primary transition-all"
+      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+    />
+  </ProgressPrimitive.Root>
+));
+Progress.displayName = ProgressPrimitive.Root.displayName;
+
+export { Progress };

--- a/rusty-rays-desktop/src/renderer/retro-ui-lib/index.ts
+++ b/rusty-rays-desktop/src/renderer/retro-ui-lib/index.ts
@@ -6,3 +6,4 @@ export * from './Input.tsx';
 export * from './Loader.tsx'
 export * from './Dialog.tsx'
 export * from './Tab.tsx'
+export * from './Progress.tsx'

--- a/rusty-rays-desktop/src/tracer-manager.ts
+++ b/rusty-rays-desktop/src/tracer-manager.ts
@@ -4,8 +4,10 @@
  */
 
 import { v4 as uuidv4 } from 'uuid';
+import type { RenderEvent } from 'rusty-rays-napi-node';
 import { Model, Tracer } from 'rusty-rays-napi-node';
 import type { RenderStatus } from '#/ipc/shared';
+import * as _ from 'lodash';
 
 type TracerInstance =
   | { uuid: string; model: Model; tracer: Tracer }
@@ -14,7 +16,8 @@ type TracerInstance =
 let tracerInstance: TracerInstance = undefined;
 let tempRenderImageData: ArrayBuffer | undefined = undefined;
 let renderStatus: RenderStatus = {
-  renderInProgress: false,
+  renderProgressPercentage: undefined,
+  writingImage: false,
   renderImageAvailable: false,
   renderErrorMsg: undefined,
   tracerInstanceUuid: undefined,
@@ -25,7 +28,7 @@ function getTracerInstance(): TracerInstance | undefined {
 }
 
 async function setModel(model: Model | undefined) {
-  if (renderStatus.renderInProgress) {
+  if (!_.isNil(renderStatus.renderProgressPercentage)) {
     throw new Error('Cannot set model. render in progress');
   }
 
@@ -46,7 +49,7 @@ async function setModel(model: Model | undefined) {
 }
 
 async function triggerRender() {
-  if (renderStatus.renderInProgress) {
+  if (!_.isNil(renderStatus.renderProgressPercentage)) {
     throw new Error('Render already in progress');
   }
 
@@ -60,10 +63,56 @@ async function triggerRender() {
   }
 
   try {
-    renderStatus.renderInProgress = true;
-    const imageData = await instance.tracer.renderToImageBuffer('png');
-    tempRenderImageData = new Uint8Array(imageData).slice().buffer;
-    renderStatus.renderImageAvailable = true;
+    let canceled = false;
+    renderStatus.renderProgressPercentage = 0;
+    const onRenderEvent = (error: unknown, event: RenderEvent) => {
+      if (error && !renderStatus.renderErrorMsg) {
+        renderStatus.renderErrorMsg =
+          'Received error during render: ' + JSON.stringify(error);
+        tracerInstance?.tracer.cancelRender().catch((error: unknown) => {
+          console.error(
+            'an error occurred while trying to cancel render:',
+            error,
+          );
+        });
+        return;
+      }
+
+      switch (event.type) {
+        case 'Progress':
+          renderStatus.renderProgressPercentage = event.percent;
+          break;
+        case 'WritingImage':
+          renderStatus.writingImage = true;
+          break;
+        case 'Finished':
+          renderStatus.renderProgressPercentage = undefined;
+          renderStatus.writingImage = false;
+          break;
+        case 'Canceled':
+          canceled = true;
+          break;
+        case 'Error':
+          renderStatus.renderErrorMsg = 'Render failed: ' + event.message;
+          break;
+        default:
+          break;
+      }
+    };
+
+    const imageData = await instance.tracer.renderToImageBuffer(
+      'png',
+      50,
+      onRenderEvent,
+    );
+
+    if (!canceled) {
+      tempRenderImageData = new Uint8Array(imageData).slice().buffer;
+      renderStatus.renderImageAvailable = true;
+    } else {
+      resetRenderStatus();
+      tempRenderImageData = undefined;
+    }
   } catch (error) {
     if (error instanceof Error) {
       renderStatus.renderErrorMsg = error.message;
@@ -71,7 +120,7 @@ async function triggerRender() {
       renderStatus.renderErrorMsg = `Unknown error: ${JSON.stringify(error)}`;
     }
   } finally {
-    renderStatus.renderInProgress = false;
+    renderStatus.renderProgressPercentage = undefined;
   }
 }
 
@@ -82,17 +131,37 @@ function takeRenderImageData() {
   return copy;
 }
 
+async function cancelRender() {
+  try {
+    await tracerInstance?.tracer.cancelRender();
+    resetRenderStatus();
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(
+        'an error occurred while trying to cancel render:',
+        error.message,
+      );
+    } else {
+      console.error(
+        'an unknown error occurred while trying to cancel render:',
+        error,
+      );
+    }
+  }
+}
+
 function getRenderStatus() {
   return { ...renderStatus, tracerInstanceUuid: tracerInstance?.uuid };
 }
 
 function resetRenderStatus() {
-  if (renderStatus.renderInProgress) {
+  if (!_.isNil(renderStatus.renderProgressPercentage)) {
     throw new Error('Cannot reset render status. Render in progress');
   }
 
   renderStatus = {
-    renderInProgress: false,
+    renderProgressPercentage: undefined,
+    writingImage: false,
     renderImageAvailable: false,
     renderErrorMsg: undefined,
     tracerInstanceUuid: tracerInstance?.uuid,
@@ -105,5 +174,6 @@ export {
   triggerRender,
   takeRenderImageData,
   getRenderStatus,
+  cancelRender,
 };
 export type { TracerInstance };

--- a/rusty-rays-desktop/src/tracer-manager.ts
+++ b/rusty-rays-desktop/src/tracer-manager.ts
@@ -106,6 +106,8 @@ async function triggerRender() {
       onRenderEvent,
     );
 
+    // if we get a cancel event from the renderer process, this will be true
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (!canceled) {
       tempRenderImageData = new Uint8Array(imageData).slice().buffer;
       renderStatus.renderImageAvailable = true;

--- a/rusty-rays-napi-node/index.ts
+++ b/rusty-rays-napi-node/index.ts
@@ -1,4 +1,4 @@
-import { createRequire } from "node:module";
+import {createRequire} from "node:module";
 import type {bindings} from "./bindings/index.d.ts";
 
 // type exports
@@ -13,6 +13,7 @@ export type Surface = bindings.Surface;
 export type Color = bindings.Color;
 export type Coords = bindings.Coords;
 export type IntersectedObjectInfo = bindings.IntersectedObjectInfo
+export type RenderEvent = bindings.RenderEvent
 
 // code exports
 const require = createRequire(import.meta.url);

--- a/rusty-rays-napi-node/src/lib.rs
+++ b/rusty-rays-napi-node/src/lib.rs
@@ -122,7 +122,7 @@ mod bindings {
         Finished { millis: u32 },
         WritingImage,
         Canceled { millis: u32 },
-        Error(String),
+        Error { message: String },
     }
 
     impl From<rusty_rays_core::RenderEvent> for RenderEvent {
@@ -137,7 +137,7 @@ mod bindings {
                 rusty_rays_core::RenderEvent::Canceled { millis } => RenderEvent::Canceled {
                     millis: millis.min(u32::MAX as u128) as u32,
                 },
-                rusty_rays_core::RenderEvent::Error(s) => RenderEvent::Error(s),
+                rusty_rays_core::RenderEvent::Error(s) => RenderEvent::Error { message: s },
             }
         }
     }

--- a/rusty-rays-napi-node/src/lib.rs
+++ b/rusty-rays-napi-node/src/lib.rs
@@ -9,8 +9,8 @@ mod bindings {
     use std::collections::HashMap;
     use std::str::FromStr;
     use std::sync::Arc;
-
     #[napi]
+
     pub fn log_error(message: String) -> napi::Result<()> {
         rusty_rays_core::logger::error!(rusty_rays_core::logger::LOG, "{}", message);
         Ok(())
@@ -116,8 +116,36 @@ mod bindings {
     }
 
     #[napi]
+    #[derive(Clone)]
+    pub enum RenderEvent {
+        Progress { percent: u8 },
+        Finished { millis: u32 },
+        WritingImage,
+        Canceled { millis: u32 },
+        Error(String),
+    }
+
+    impl From<rusty_rays_core::RenderEvent> for RenderEvent {
+        fn from(core_event: rusty_rays_core::RenderEvent) -> Self {
+            match core_event {
+                rusty_rays_core::RenderEvent::Progress { percent } => {
+                    RenderEvent::Progress { percent }
+                }
+                rusty_rays_core::RenderEvent::Finished { millis } => RenderEvent::Finished {
+                    millis: millis.min(u32::MAX as u128) as u32,
+                },
+                rusty_rays_core::RenderEvent::Canceled { millis } => RenderEvent::Canceled {
+                    millis: millis.min(u32::MAX as u128) as u32,
+                },
+                rusty_rays_core::RenderEvent::Error(s) => RenderEvent::Error(s),
+            }
+        }
+    }
+
+    #[napi]
     pub struct Tracer {
         inner: Arc<tokio::sync::Mutex<rusty_rays_core::Tracer>>,
+        current_render_cancel: Arc<tokio::sync::Mutex<Option<rusty_rays_core::CancellationToken>>>,
     }
 
     #[napi]
@@ -130,51 +158,94 @@ mod bindings {
 
             Ok(Self {
                 inner: Arc::new(tokio::sync::Mutex::new(tracer)),
+                current_render_cancel: Arc::new(tokio::sync::Mutex::new(None)),
             })
         }
 
         #[napi]
-        pub async fn render_to_image_buffer(&self, image_format: String) -> napi::Result<Buffer> {
-            let inner_tracer_clone = self.inner.clone();
-            let raw_image = tokio::task::spawn_blocking(move || {
-                let tracer_guard = inner_tracer_clone.blocking_lock();
+        pub async fn render_to_image_buffer(
+            &self,
+            image_format: String,
+            num_progress_blocks: i64,
+            on_event: napi::threadsafe_function::ThreadsafeFunction<RenderEvent>,
+        ) -> napi::Result<Buffer> {
+            let inner = self.inner.clone();
+            let on_event = Arc::new(on_event);
+            let write_image = move |raw_render| {
+                rusty_rays_core::write_render_to_image_buffer(image_format, &raw_render)
+                    .map(Buffer::from)
+                    .map_err(|e| e.to_string())
+            };
 
-                let raw_render = match tracer_guard.render() {
-                    Ok(render) => render,
-                    Err(error) => return Err(error.to_string()),
-                };
+            let cancel_token = rusty_rays_core::CancellationToken::default();
+            self.current_render_cancel
+                .lock()
+                .await
+                .replace(cancel_token.clone());
 
-                match rusty_rays_core::write_render_to_image_buffer(image_format, &raw_render) {
-                    Ok(serialized_render) => Ok(Buffer::from(serialized_render)),
-                    Err(error) => Err(error.to_string()),
-                }
-            })
-            .await
-            .map_err(|e| napi::Error::from_reason(format!("task panicked: {e}")))?
-            .map_err(napi::Error::from_reason)?;
+            let handle = Self::spawn_blocking_render_with_events(
+                inner,
+                cancel_token,
+                num_progress_blocks,
+                on_event,
+                write_image,
+            );
 
-            Ok(raw_image)
+            let buf = handle
+                .await
+                .map_err(|e| napi::Error::from_reason(format!("task panicked: {e}")))?
+                .map_err(napi::Error::from_reason)?;
+
+            self.clear_cancel_token().await;
+
+            Ok(buf)
         }
 
         #[napi]
-        pub async fn render_to_file(&self, output_file_path: String) -> napi::Result<()> {
-            let inner_tracer_clone = self.inner.clone();
-            tokio::task::spawn_blocking(move || {
-                let tracer_guard = inner_tracer_clone.blocking_lock();
-                let raw_render = match tracer_guard.render() {
-                    Ok(render) => render,
-                    Err(error) => return Err(error.to_string()),
-                };
+        pub async fn render_to_file(
+            &self,
+            output_file_path: String,
+            num_progress_blocks: i64,
+            on_event: napi::threadsafe_function::ThreadsafeFunction<RenderEvent>,
+        ) -> napi::Result<()> {
+            let inner = self.inner.clone();
+            let on_event = Arc::new(on_event);
+            let write_image = move |raw_render| {
+                rusty_rays_core::write_render_to_file(&output_file_path.into(), &raw_render)
+                    .map_err(|e| e.to_string())?;
+                Ok(())
+            };
 
-                match rusty_rays_core::write_render_to_file(&output_file_path.into(), &raw_render) {
-                    Ok(serialized_render) => Ok(serialized_render),
-                    Err(error) => Err(error.to_string()),
-                }
-            })
-            .await
-            .map_err(|e| napi::Error::from_reason(format!("task panicked: {e}")))?
-            .map_err(napi::Error::from_reason)?;
+            let cancel_token = rusty_rays_core::CancellationToken::default();
+            self.current_render_cancel
+                .lock()
+                .await
+                .replace(cancel_token.clone());
 
+            let handle = Self::spawn_blocking_render_with_events(
+                inner,
+                cancel_token,
+                num_progress_blocks,
+                on_event,
+                write_image,
+            );
+
+            handle
+                .await
+                .map_err(|e| napi::Error::from_reason(format!("task panicked: {e}")))?
+                .map_err(napi::Error::from_reason)?;
+
+            self.clear_cancel_token().await;
+
+            Ok(())
+        }
+
+        #[napi]
+        pub async fn cancel_render(&self) -> napi::Result<()> {
+            if let Some(token) = self.current_render_cancel.lock().await.clone() {
+                token.cancel();
+            }
+            self.clear_cancel_token().await;
             Ok(())
         }
 
@@ -193,6 +264,86 @@ mod bindings {
                 });
 
             Ok(result)
+        }
+
+        fn spawn_blocking_render_with_events<T, F>(
+            inner: Arc<tokio::sync::Mutex<rusty_rays_core::Tracer>>,
+            cancel_token: rusty_rays_core::CancellationToken,
+            num_progress_blocks: i64,
+            on_event: Arc<napi::threadsafe_function::ThreadsafeFunction<RenderEvent>>,
+            write_image: F,
+        ) -> tokio::task::JoinHandle<Result<T, String>>
+        where
+            T: Send + 'static,
+            F: FnOnce(Vec<Vec<rusty_rays_core::Color>>) -> Result<T, String> + Send + 'static,
+        {
+            tokio::task::spawn_blocking(move || -> Result<T, String> {
+                // Channel that core uses to emit RenderEvent values.
+                let (tx, rx) = std::sync::mpsc::channel::<rusty_rays_core::RenderEvent>();
+
+                // Forward core events to JS on a dedicated listener thread.
+                let on_event_listener = on_event.clone();
+                let listener_handle = std::thread::spawn(move || {
+                    let mut render_time_millis = 0;
+                    for core_render_event in rx.iter() {
+                        let render_event: RenderEvent = core_render_event.into();
+                        if let RenderEvent::Finished { millis } = render_event {
+                            // we're not done until the render has been written as an image
+                            // do not send the finished event on render completion
+                            render_time_millis = millis;
+                        } else {
+                            let _ = on_event_listener.call(
+                                Ok(render_event.into()),
+                                napi::threadsafe_function::ThreadsafeFunctionCallMode::NonBlocking,
+                            );
+                        }
+                    }
+
+                    render_time_millis
+                });
+
+                let tracer_guard = inner.blocking_lock();
+                let raw_render = match tracer_guard.render(
+                    Some(cancel_token),
+                    Some(tx),
+                    Some(num_progress_blocks as usize),
+                ) {
+                    Ok(render) => render,
+                    Err(error) => {
+                        // Ensure listener can exit cleanly.
+                        let _ = listener_handle.join();
+                        return Err(error.to_string());
+                    }
+                };
+
+                // Join the listener (rx will be closed because tx was dropped when render returned).
+                let listener_join_result = listener_handle.join();
+                let render_time_millis = match listener_join_result {
+                    Ok(t) => t,
+                    Err(_) => return Err("Render listener thread panicked".to_string()),
+                };
+
+                let _ = on_event.call(
+                    Ok(RenderEvent::WritingImage),
+                    napi::threadsafe_function::ThreadsafeFunctionCallMode::NonBlocking,
+                );
+
+                // Do the endpoint-specific final step.
+                let write_result = write_image(raw_render);
+
+                let _ = on_event.call(
+                    Ok(RenderEvent::Finished {
+                        millis: render_time_millis,
+                    }),
+                    napi::threadsafe_function::ThreadsafeFunctionCallMode::NonBlocking,
+                );
+
+                write_result
+            })
+        }
+
+        async fn clear_cancel_token(&self) {
+            let _ = self.current_render_cancel.lock().await.take();
         }
     }
 

--- a/rusty-rays-napi-node/src/lib.rs
+++ b/rusty-rays-napi-node/src/lib.rs
@@ -293,7 +293,7 @@ mod bindings {
                             render_time_millis = millis;
                         } else {
                             let _ = on_event_listener.call(
-                                Ok(render_event.into()),
+                                Ok(render_event),
                                 napi::threadsafe_function::ThreadsafeFunctionCallMode::NonBlocking,
                             );
                         }

--- a/rusty-rays-napi-node/test.ts
+++ b/rusty-rays-napi-node/test.ts
@@ -7,6 +7,7 @@ import {
     logTrace,
     logWarn,
     Model,
+    type RenderEvent,
     setConfig,
     shutdownLogger,
     type Sphere,
@@ -56,7 +57,24 @@ async function main() {
     await model.upsertSphere(newSphere);
     console.log("second sphere successfully added");
     const tracer = await Tracer.create(model);
-    await tracer.renderToFile(`${testArtifactDir}/jsRender.png`);
+
+    const onRenderEvent = (_: unknown, event: RenderEvent) => {
+        console.log('render event:', JSON.stringify(event));
+    }
+    // do not await and test cancellation
+    console.log('starting render to test cancellation');
+    tracer
+        .renderToFile(`${testArtifactDir}/jsRender.png`, 20, onRenderEvent)
+        .catch((error) => console.error('caught exception from render function', error));
+
+    console.log('cancelling render');
+    setTimeout(() => tracer.cancelRender(), 100);
+
+    // give cancel test time to complete
+    await new Promise((resolve) => setTimeout(resolve, 3000))
+
+    console.log('awaiting render test');
+    await tracer.renderToFile(`${testArtifactDir}/jsRender.png`, 20, onRenderEvent);
 
     shutdownLogger();
 }

--- a/sample-files/jacks.ray
+++ b/sample-files/jacks.ray
@@ -3,7 +3,7 @@ eyep 2 1 -8
 lookp 0 0 0
 up 0 1 0
 fov 25 25
-screen 4500 4500
+screen 8000 8000
 sample 1 nojitter
 light 1 extended 0.5 -10 3 -20
 light 1 extended 0.5 5 8 -5

--- a/sample-files/single-sphere-test-point.ray
+++ b/sample-files/single-sphere-test-point.ray
@@ -3,7 +3,7 @@ eyep 1.7 1.1 1.5
 lookp 0 0 0
 up 0 0 1
 fov 45 45
-screen 1512 1512
+screen 8000 8000
 light 0.57735 point 4 3 2
 light 0.57735 point 1 -4 4
 light 0.57735 point -3 1 5


### PR DESCRIPTION
This PR adds progress event emission from the render algorithm via MPSC and the ability to cancel the render process. The napi bindings have also been updated to invoke a callback passed in from the JS runtime which is called on render events.

The desktop app tracer manager and loading layout how been updated to respond to render progress state.

Additionally this PR adds a critical fix in which the contiguous vector allocation of the pre-computed ray definitions at the start of the render algorithm caused the electron main node process to SIGTRAP on linux for sufficiently large images.